### PR TITLE
Fix Liquid warning for offending parentheses

### DIFF
--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -11,9 +11,9 @@
     {% include header.html %}
 
     <div id="container"
-          {% if(page.ishome) %} class="home-page-container" {% endif %}
-          {% if(page.isfullheight) %} class="full-height" {% endif %}
-          {% if(page.isculture) %} class="culture-page-container" {% endif %}>
+          {% if page.ishome %} class="home-page-container" {% endif %}
+          {% if page.isfullheight %} class="full-height" {% endif %}
+          {% if page.isculture %} class="culture-page-container" {% endif %}>
 
       {{ content }}
 


### PR DESCRIPTION
Running `jekyll build` produced multiple warnings.

`Liquid Warning: Liquid syntax error (line 14): Expected dotdot but found close_round in "(page.ishome)" in /_layouts/default.html`
