### PR TITLE
Ensure menu items are smaller font size on shorter screen height

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -4466,8 +4466,8 @@ address {
 }
 
 @media screen and (max-height: 500px) {
-  /* Smaller menu font size on shorter view  */
-  .ms-menu-list {
+  /* Force smaller menu font size on shorter view  */
+  #menu-list {
     font-size: 3.2rem;
   }
 }

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -4464,3 +4464,10 @@ address {
   }
 
 }
+
+@media screen and (max-height: 500px) {
+  /* Smaller menu font size on shorter view  */
+  .ms-menu-list {
+    font-size: 3.2rem;
+  }
+}


### PR DESCRIPTION
Added a media query to ensure that for a given view height, menu items are always at smaller font size no matter screen width.