### PR TITLE
Exclude email_sig directory from deploy cleanup

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -97,6 +97,6 @@ gulp.task('deploy', function () {
       archive: true,
       clean: true,
       recursive: true,
-      exclude: ['.htaccess']
+      exclude: ['.htaccess', 'email_sig']
     }))
 })


### PR DESCRIPTION
@msandrew has added an `email_sig` directory as a place to store email signature images https://www.mediasuite.co.nz/email_sig/juliaisgreat.png. Wah 404?!? Thought it best we don't clobber the dir next deployment. 😬 